### PR TITLE
Fixed Mac: Seil hyperlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Contents
   * [Linux: xmodmap](#linux-xmodmap)
   * [Linux: loadkeys](#linux-loadkeys)
   * [Mac: System Preferences](#mac-system-preferences)
-  * [Mac: Seil](#mac-os-x-seil)
+  * [Mac: Seil](#mac-seil)
 * [Resources](#resources)
 * [License](#license)
 * [Support](#support)


### PR DESCRIPTION
The previous link was broken. I updated the link in the table of contents to reflect the correct header name so that the GitHub markdown creates the right link :).

Also, this is a fantastic executable. Thank you for this! 