### PR TITLE
Add FreeConsole() call to ensure console window always gets hidden

### DIFF
--- a/uncap.c
+++ b/uncap.c
@@ -624,6 +624,8 @@ int main(int argc, char **argv)
             ShowWindow(h, SW_HIDE);
         else
             error("Cannot find console window; error %lu.", GetLastError());
+            
+        FreeConsole();
     }
 
     /* Install hook to monitor low-level keyboard input events. */


### PR DESCRIPTION
Fix for https://github.com/susam/uncap/issues/6

Steps to reproduce:
1. Launch a [cmder](http://cmder.net/) console
2. Double-click `uncap.exe` from a File Explorer - rather than launching from a console
3. Uncap shows an empty console output window

The issue is likely to do with ConEmu's hooking of consoles, but didn't investigate further since this simple fix worked for me