### PR TITLE
docs: fix simple typo, argments -> arguments

### DIFF
--- a/uncap.c
+++ b/uncap.c
@@ -159,7 +159,7 @@ struct state {
 Output error message on the standard error stream.
 
 @param format Format string for printf.
-@param ...    Additional argments.
+@param ...    Additional arguments.
 
 @return EXIT_FAILURE; the caller of this function may return this code
         to indicate abnormal termination of the program.


### PR DESCRIPTION
There is a small typo in uncap.c.

Should read `arguments` rather than `argments`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md